### PR TITLE
Fixing a typo in Exercise 6.

### DIFF
--- a/src/exercises/ez-changing-transformations.xml
+++ b/src/exercises/ez-changing-transformations.xml
@@ -66,7 +66,7 @@
           </li>
           <li>
             <p>
-              Let <m>h(x) = f(x-2)</m>.  For <m>f</m>, recall that you determined <m>AV_{[-3,-1]}</m> and <m>AV_{[2,5]}</m> in (a).  In addition, determine <m>AV_{[-1,-1]}</m> and <m>AV_{[4,7]}</m> for <m>h</m>.  What do you observe?  Why does this phenomenon occur?
+              Let <m>h(x) = f(x-2)</m>.  For <m>f</m>, recall that you determined <m>AV_{[-3,-1]}</m> and <m>AV_{[2,5]}</m> in (a).  In addition, determine <m>AV_{[-1,1]}</m> and <m>AV_{[4,7]}</m> for <m>h</m>.  What do you observe?  Why does this phenomenon occur?
             </p>
           </li>
           <li>


### PR DESCRIPTION
 We want to compute AV[-1, 1], not AV[-1, -1].