### PR TITLE
Updates to get working with July 2020 PTX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,25 +113,17 @@ pg:
 
 apc-extraction:
 	install -d $(WWOUT)
-	-rm $(WWOUT)/webwork-extraction.xml
+	-rm $(WWOUT)/webwork-representations.ptx
 	-rm $(WWOUT)/webwork-*-image*
-	PYTHONWARNINGS=module $(MB)/script/mbx -v -c webwork -d $(WWOUT) -s $(SERVER) $(MAINFILE)
+	PYTHONWARNINGS=module $(MB)/pretext/pretext -c webwork -d $(WWOUT) -s $(SERVER) $(MAINFILE)
 	cd $(WWOUT); \
 	gif2png -O *.gif
-
-#  Make a new PTX file from the source tree, with webwork elements replaced
-#  by the webwork-reps from webwork-extraction.xml. (So run the above at
-#  least once first.) Subsequent templates are applied to the result.
-
-apc-merge:
-	cd $(WWOUT); \
-	xsltproc -xinclude  --stringparam webwork.extraction $(WWOUT)/webwork-extraction.xml $(MBXSL)/pretext-merge.xsl $(MAINFILE) > apc-merge.ptx
 
 #  HTML output 
 #  Output lands in the subdirectory:  $(HTMLOUT)
 #    Remove the entire $(HTMLOUT)/knowl directory because of how PTX now
 #    seems to make a knowl for everything and rm throws an error.
-html:  apc-merge 
+html:
 	install -d $(HTMLOUT)
 	-rm -rf $(HTMLOUT)/knowl
 	install -d $(HTMLOUT)/knowl
@@ -146,7 +138,7 @@ html:  apc-merge
 	cp -a $(IMAGESSRC) $(HTMLOUT)
 	cp -a $(PRJSRC)/interactives $(HTMLOUT)
 	cd $(HTMLOUT); \
-	xsltproc -xinclude $(MBUSR)/apc-html.xsl $(WWOUT)/apc-merge.ptx
+	xsltproc -xinclude -stringparam publisher $(PRJ)/pub/html.xml $(MBUSR)/apc-html.xsl $(MAINFILE)
 
 # make all the image files in svg format
 images:

--- a/pub/html.xml
+++ b/pub/html.xml
@@ -1,0 +1,6 @@
+<publication>
+  <source webwork-problems="../output/webwork-extraction/webwork-representations.ptx"/>
+  <html>
+    <css colors="blue_grey" />
+  </html>
+</publication>

--- a/src/activities/act-exp-log-natural.xml
+++ b/src/activities/act-exp-log-natural.xml
@@ -15,104 +15,104 @@
 
 <activity xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="act-exp-log-natural">
 
-	<statement>
-		<p>
-			Let <m>E(t) = e^t</m> and <m>N(y) = \ln(y)</m> be the natural exponential function and the natural logarithm function, respectively.
-		</p>
+  <statement>
+    <p>
+      Let <m>E(t) = e^t</m> and <m>N(y) = \ln(y)</m> be the natural exponential function and the natural logarithm function, respectively.
+    </p>
 
-		<p>
-			<ol label="a.">
-				<li>
-					<p>
-						What are the domain and range of <m>E</m>?
-					</p>
-				</li>
-				<li>
-					<p>
-						What are the domain and range of <m>N</m>?
-					</p>
-				</li>
-				<li>
-					<p>
-						What can you say about <m>\ln(e^t)</m> for every real number <m>t</m>?
-					</p>
-				</li>
-				<li>
-					<p>
-						What can you say about <m>e^{\ln(y)}</m> for every positive real number <m>y</m>?
-					</p>
-				</li>
-				<li>
-					<p>
-						Complete <xref ref="T-act-natural-e">Table</xref> and <xref ref="T-act-natural-log">Table</xref> with both exact and approximate values of <m>E</m> and <m>N</m>.  Then, plot the corresponding ordered pairs from each table on the axes provided in <xref ref="F-axes-e-ln">Figure</xref> and connect the points in an intuitive way.  When you plot the ordered pairs on the axes, in both cases view the first line of the table as generating values on the horizontal axis and the second line of the table as producing values on the vertical axis<fn>Note that when we take this perspective for plotting the data in <xref ref="T-act-natural-log">Table</xref>, we are viewing <m>N</m> as a function of <m>t</m>, writing <m>N(t) = \ln(t)</m> in order to plot the function on the <m>t</m>-<m>y</m> axes</fn>; label each ordered pair you plot appropriately.
-					</p>
+    <p>
+      <ol label="a.">
+	<li>
+	  <p>
+	    What are the domain and range of <m>E</m>?
+	  </p>
+	</li>
+	<li>
+	  <p>
+	    What are the domain and range of <m>N</m>?
+	  </p>
+	</li>
+	<li>
+	  <p>
+	    What can you say about <m>\ln(e^t)</m> for every real number <m>t</m>?
+	  </p>
+	</li>
+	<li>
+	  <p>
+	    What can you say about <m>e^{\ln(y)}</m> for every positive real number <m>y</m>?
+	  </p>
+	</li>
+	<li>
+	  <p>
+	    Complete <xref ref="T-act-natural-e">Table</xref> and <xref ref="T-act-natural-log">Table</xref> with both exact and approximate values of <m>E</m> and <m>N</m>.  Then, plot the corresponding ordered pairs from each table on the axes provided in <xref ref="F-axes-e-ln">Figure</xref> and connect the points in an intuitive way.  When you plot the ordered pairs on the axes, in both cases view the first line of the table as generating values on the horizontal axis and the second line of the table as producing values on the vertical axis<fn>Note that when we take this perspective for plotting the data in <xref ref="T-act-natural-log">Table</xref>, we are viewing <m>N</m> as a function of <m>t</m>, writing <m>N(t) = \ln(t)</m> in order to plot the function on the <m>t</m>-<m>y</m> axes</fn>; label each ordered pair you plot appropriately.
+	  </p>
 
-					<sidebyside widths="57% 43%">
-						<p>
-							<table xml:id="T-act-natural-e">
-								<caption>Values of <m>y = E(t)</m>.</caption>
-								<tabular>
-									<row bottom="minor" halign="center">
-										<cell><m>t</m></cell>
-										<cell><m>-2</m></cell>
-										<cell><m>-1</m></cell>
-										<cell><m>0</m></cell>
-										<cell><m>1</m></cell>
-										<cell><m>2</m></cell>
-									</row>
-									<row>
-										<cell><m>E(t)=e^t</m></cell>
-										<cell><m>e^{-2} \approx 0.135</m></cell>
-										<cell></cell>
-										<cell></cell>
-										<cell></cell>
-										<cell></cell>
-									</row>
-								</tabular>
-							</table>
+	  <sidebyside widths="57% 43%">
+	    <p>
+	      <table xml:id="T-act-natural-e">
+		<title>Values of <m>y = E(t)</m>.</title>
+		<tabular>
+		  <row bottom="minor" halign="center">
+		    <cell><m>t</m></cell>
+		    <cell><m>-2</m></cell>
+		    <cell><m>-1</m></cell>
+		    <cell><m>0</m></cell>
+		    <cell><m>1</m></cell>
+		    <cell><m>2</m></cell>
+		  </row>
+		  <row>
+		    <cell><m>E(t)=e^t</m></cell>
+		    <cell><m>e^{-2} \approx 0.135</m></cell>
+		    <cell></cell>
+		    <cell></cell>
+		    <cell></cell>
+		    <cell></cell>
+		  </row>
+		</tabular>
+	      </table>
 
-							<table xml:id="T-act-natural-log">
-								<caption>Values of <m>t = N(y)</m>.</caption>
-								<tabular>
-									<row bottom="minor" halign="center">
-										<cell><m>y</m></cell>
-										<cell><m>e^{-2}</m></cell>
-										<cell><m>e^{-1}</m></cell>
-										<cell><m>1</m></cell>
-										<cell><m>e^1</m></cell>
-										<cell><m>e^2</m></cell>
-									</row>
-									<row>
-										<cell><m>N(y)=\ln(y)</m></cell>
-										<cell><m>-2</m></cell>
-										<cell></cell>
-										<cell></cell>
-										<cell></cell>
-										<cell></cell>
-									</row>
-								</tabular>
-							</table>
-						</p>
+	      <table xml:id="T-act-natural-log">
+		<title>Values of <m>t = N(y)</m>.</title>
+		<tabular>
+		  <row bottom="minor" halign="center">
+		    <cell><m>y</m></cell>
+		    <cell><m>e^{-2}</m></cell>
+		    <cell><m>e^{-1}</m></cell>
+		    <cell><m>1</m></cell>
+		    <cell><m>e^1</m></cell>
+		    <cell><m>e^2</m></cell>
+		  </row>
+		  <row>
+		    <cell><m>N(y)=\ln(y)</m></cell>
+		    <cell><m>-2</m></cell>
+		    <cell></cell>
+		    <cell></cell>
+		    <cell></cell>
+		    <cell></cell>
+		  </row>
+		</tabular>
+	      </table>
+	    </p>
 
-						<figure xml:id="F-axes-e-ln">
-							<caption>Axes for plotting data from <xref ref="T-act-natural-e">Table</xref> and <xref ref="T-act-natural-log">Table</xref> along with the graphs of the natural exponential and natural logarithm functions.</caption>
-							<image source="images/exp-log-blank-axes" />
-						</figure>
-					</sidebyside>
-				</li>
-			</ol>
-		</p>
-	</statement>
-	<answer>
-		<p>
-			
-		</p>
-	</answer>
-	<solution>
-		<p>
-			
-		</p>
-	</solution>
+	    <figure xml:id="F-axes-e-ln">
+	      <caption>Axes for plotting data from <xref ref="T-act-natural-e">Table</xref> and <xref ref="T-act-natural-log">Table</xref> along with the graphs of the natural exponential and natural logarithm functions.</caption>
+	      <image source="images/exp-log-blank-axes" />
+	    </figure>
+	  </sidebyside>
+	</li>
+      </ol>
+    </p>
+  </statement>
+  <answer>
+    <p>
+      
+    </p>
+  </answer>
+  <solution>
+    <p>
+      
+    </p>
+  </solution>
 
 </activity>
 

--- a/src/frontmatter.xml
+++ b/src/frontmatter.xml
@@ -275,7 +275,7 @@
   <preface xml:id="preface-for-instructors">
     <title>Instructors!  Read this!</title>
     <p>
-      This book is different.  Before you read further, first read <xref ref="preface-for-students" text="title"><q>Students! Read this!</q></xref> as well as <xref ref="preface-our-goals" text="title"><q>Our Goals</q></xref>.
+      This book is different.  Before you read further, first read <xref ref="preface-for-students" text="custom"><q>Students! Read this!</q></xref> as well as <xref ref="preface-our-goals" text="custom"><q>Our Goals</q></xref>.
     </p>
 
     <p>

--- a/src/frontmatter.xml
+++ b/src/frontmatter.xml
@@ -40,14 +40,14 @@
       This first public offering of the text in 2019 will benefit immensely from user feedback and suggestions.  I welcome hearing from you.
     </p>
 
-  <attribution>
+<!--  <attribution>
     <line>Matt Boelkins</line>
     <line>Allendale, MI</line>
     <line>August 2019</line>
     <line>
     <email>boelkinm@gvsu.edu</email>
     </line>
-    </attribution>
+    </attribution>-->
 
   </acknowledgement>
 

--- a/src/sec-changing-combining.xml
+++ b/src/sec-changing-combining.xml
@@ -191,7 +191,7 @@
 			    is the absolute value function: <m>A(x) = |x|</m>.
 			    We know that if <m>x \ge 0</m>, <m>|x| = x</m>, whereas if <m>x \lt 0</m>, <m>|x| = -x</m>.  
 			</p>
-                        <p>
+			<p>
 	  		<definition xml:id="def-combining-abs-val">
 	  				<idx><h>absolute value function</h></idx>
 					<statement>

--- a/src/sec-circular-sinusoidal.xml
+++ b/src/sec-circular-sinusoidal.xml
@@ -191,7 +191,7 @@
 
   <subsection xml:id="subsec-circular-sinusoidal-summary">
   	<title>Summary</title>
-
+	<p>
 	<ul>
   		<li>
   			<p>
@@ -217,7 +217,7 @@
   			</p>
   		</li>
   	</ul>
-
+	</p>
   </subsection>
 
   <xi:include href="./exercises/ez-circular-sinusoidal.xml" />

--- a/src/sec-exp-growth.xml
+++ b/src/sec-exp-growth.xml
@@ -339,7 +339,8 @@
 
   <subsection>
   	<title>Summary</title>
-  	 <ul>
+	<p>
+  	<ul>
   		<li>
   			<p>
   				We say that a function is exponential whenever its algebraic form is <m>f(t) = ab^t</m> for some positive constants <m>a</m> and <m>b</m> where <m>b \ne 1</m>.  (Technically, the formal definition of an exponential function is one of form <m>f(t) = b^t</m>, but in our everyday usage of the term <q>exponential</q> we include vertical stretches of these functions and thus allow <m>a</m> to be any positive constant, not just <m>a = 1</m>.)
@@ -387,6 +388,7 @@
   			</p>
   		</li>
   	</ul>
+	</p>
   </subsection>
 
   <xi:include href="./exercises/ez-exp-growth.xml" />

--- a/src/sec-trig-right.xml
+++ b/src/sec-trig-right.xml
@@ -144,7 +144,6 @@
 
 	<assemblage xml:id="asm-trig-right-SOH-CAH">
 		<title>Ratios in right triangles</title>
-		<p>
 			<sidebyside widths="60% 40%">
 				<p>
 					In a right triangle where one of the non-right angles is <m>\theta</m>, and <q>adj</q> denotes the length of the leg adjacent to <m>\theta</m>, <q>opp</q> the length the side opposite <m>\theta</m>, and <q>hyp</q> the length of the hypotenuse,
@@ -156,7 +155,6 @@
 				<image source="images/right-triangle-SOH-CAH" width="50%" />
 
 			</sidebyside>
-		</p>
 	</assemblage>
 
 	<xi:include href="./activities/act-trig-right-SOH-CAH.xml" />

--- a/xsl/apc-html.xsl
+++ b/xsl/apc-html.xsl
@@ -18,7 +18,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
 <!-- Assumes current file is in mathbook/user, so it must be copied there -->
-<xsl:import href="../xsl/mathbook-html.xsl" />
+<xsl:import href="../xsl/pretext-html.xsl" />
 <!-- Assumes next file can be found in mathbook/user, so it must be copied there -->
 <!--<xsl:import href="acs-common.xsl" />-->
 
@@ -42,10 +42,6 @@
 <xsl:param name="project.hint" select="'no'" />
 <xsl:param name="project.answer" select="'no'" />
 <xsl:param name="project.solution" select="'no'" />
-
-<!-- Specify the color scheme to use for HTML -->
-<xsl:param name="debug.colors" select="'blue_grey'" />  <!-- this is what we use for ACS -->
-
 
 <!-- Specify options for WeBWorK exercises -->
 <xsl:param name="webwork.divisional.static" select="'no'" />


### PR DESCRIPTION
Compilation process using `make` remains the same with `make apc-extraction` followed by `make html`, but some changes behind the scenes. `pull` mathbook before trying to run the updates that this PR provides.

Almost surely you're going to get some script issues with `make apc-extraction`, @mattboelkins, since a couple of Python packages may need to be installed. Email me the errors and I'll let you know what you need to do.