### PR TITLE
Correcting name of function in table

### DIFF
--- a/src/activities/act-changing-inverse-does-it.xml
+++ b/src/activities/act-changing-inverse-does-it.xml
@@ -67,7 +67,7 @@
 					        <cell>4</cell>
 					      </row>
 					      <row>
-					        <cell><m>f(x)</m></cell>
+					        <cell><m>g(x)</m></cell>
 					        <cell>4</cell>
 					        <cell>0</cell>
 					        <cell>3</cell>


### PR DESCRIPTION
The function in part b. is called "g" in the text but "f(x)" in the table. This fixes the typo.