### PR TITLE
V should be a function of s, not of l

### DIFF
--- a/src/exercises/ez-poly-polynomial-applications.xml
+++ b/src/exercises/ez-poly-polynomial-applications.xml
@@ -64,7 +64,7 @@
           </li>
           <li>
             <p>
-              Use your work in (d) and (b) to express the volume of the trough, <m>V</m>, as a function of <m>l</m> only.
+              Use your work in (d) and (b) to express the volume of the trough, <m>V</m>, as a function of <m>s</m> only.
             </p>
           </li>
           <li>


### PR DESCRIPTION
Part (d) has students solve for l in terms of s; substituting this into the formula developed in part (b) produces a function of s only.
(Also, philosophically, V(s) is a polynomial but V(l) isn't, I don't think.)