### PR TITLE
Hide hints and change Mitch's affiliation

### DIFF
--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -16,8 +16,8 @@
   <common>
     <!-- List Chapters and Sections in sidebar Table of Contents -->
     <tableofcontents level="2" />
-    <exercise-divisional statement="yes" hint="yes" answer="no" solution="no"/>
-    <exercise-project statement="yes" hint="yes" answer="no" solution="no" />
+    <exercise-divisional statement="yes" hint="no" answer="no" solution="no"/>
+    <exercise-project statement="yes" hint="no" answer="no" solution="no" />
   </common>
   <webwork server="https://webwork-ptx.aimath.org" />
 </publication>

--- a/source/titlepage.xml
+++ b/source/titlepage.xml
@@ -25,9 +25,9 @@
       <title>Production Editor</title>
       <author>
         <personname>Mitchel T. Keller</personname>
-        <department>Department of Natural and Mathematical Sciences</department>
-        <institution>Morningside College</institution>
-        <email>kellerm@morningside.edu</email>
+        <department>Department of Mathematics</department>
+        <institution>University of Wisconsin-Madison</institution>
+        <email>mitch@rellek.net</email>
       </author>
     </credit>
 


### PR DESCRIPTION
This got fixed on ACS but not on APC. I'm going to merge right away and @davidfarmer should pull the updated version before building for posting.