### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Active Prelude to Calculus
 Repository for the PreTeXt source for Active Prelude to Calculus.
 
-Active Prelude to Calculus is available from https://www.activecalculus.org/prep. 
+Active Prelude to Calculus is available from https://www.activecalculus.org/apc. 
 
 # quickstart instructions
 1. Clone this repository.


### PR DESCRIPTION
The link to the Active Calculus website took me to a 'Page Not Found' - updated to go to the Active Prelude to Calculus homepage instead. 

The PyPI page linked for [PreTeXt-CLI](https://pypi.org/project/pretextbook/) also points visitors to a new URL: https://pypi.org/project/pretext/
let me know if I should update that as well. 