### PR TITLE
Labels for WeBWorK

### DIFF
--- a/source/exercises/ez-0-0.xml
+++ b/source/exercises/ez-0-0.xml
@@ -14,10 +14,10 @@
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-0-0-0">
   
 <!--
-  <exercise xml:id="ez-0-0-WW1">
+  <exercise xml:id="ez-0-0-WW1" label="Library__Michigan__Chap2Sec1__Q17">
     <webwork source="Library/Michigan/Chap2Sec1/Q17.pg" />
   </exercise>
-  <exercise xml:id="ez-0-0-WW2">
+  <exercise xml:id="ez-0-0-WW2" label="Library__Michigan__Chap2Sec1__Q17">
     <webwork source="Library/Michigan/Chap2Sec1/Q17.pg" />
   </exercise>
 -->

--- a/source/exercises/ez-changing-aroc.xml
+++ b/source/exercises/ez-changing-aroc.xml
@@ -13,28 +13,28 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-changing-aroc">
 
-  <exercise xml:id="ez-changing-aroc-WW1">
+  <exercise xml:id="ez-changing-aroc-WW1" label="Library__Michigan__precalc__4e__Chap1Sec2__Q04">
     <webwork source="Library/Michigan/precalc/4e/Chap1Sec2/Q04.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-aroc-WW2">
+  <exercise xml:id="ez-changing-aroc-WW2" label="Library__Michigan__precalc__4e__Chap1Sec2__Q15">
     <webwork source="Library/Michigan/precalc/4e/Chap1Sec2/Q15.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-aroc-WW3">
+  <exercise xml:id="ez-changing-aroc-WW3" label="Library__Michigan__precalc__4e__Chap1Sec2__Q23">
     <webwork source="Library/Michigan/precalc/4e/Chap1Sec2/Q23.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-aroc-WW4">
+  <exercise xml:id="ez-changing-aroc-WW4" label="Library__LoyolaChicago__Precalc__Chap1Review__Q06">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Review/Q06.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-aroc-WW5">
+  <exercise xml:id="ez-changing-aroc-WW5" label="Library__LoyolaChicago__Precalc__Chap1Sec2__Q03">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec2/Q03.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-aroc-WW6">
+  <exercise xml:id="ez-changing-aroc-WW6" label="Library__LoyolaChicago__Precalc__Chap1Sec2__Q10">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec2/Q10.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-aroc-WW7">
+  <exercise xml:id="ez-changing-aroc-WW7" label="Library__LoyolaChicago__Precalc__Chap1Sec2__Q16">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec2/Q16.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-aroc-WW8">
+  <exercise xml:id="ez-changing-aroc-WW8" label="Library__LoyolaChicago__Precalc__Chap1Sec2__Q25">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec2/Q25.pg"/>
   </exercise>
 

--- a/source/exercises/ez-changing-combining.xml
+++ b/source/exercises/ez-changing-combining.xml
@@ -13,34 +13,34 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-changing-combining">
 
-  <exercise xml:id="ez-changing-combining-WW1">
+  <exercise xml:id="ez-changing-combining-WW1" label="Library__CollegeOfIdaho__setAlgebra_02_02_AlgebraOfFunctions__22IntAlg_05_functOperation">
     <webwork source="Library/CollegeOfIdaho/setAlgebra_02_02_AlgebraOfFunctions/22IntAlg_05_functOperation.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-combining-WW2">
+  <exercise xml:id="ez-changing-combining-WW2" label="Library__CollegeOfIdaho__setAlgebra_02_02_AlgebraOfFunctions__22IntAlg_07_functOperation">
     <webwork source="Library/CollegeOfIdaho/setAlgebra_02_02_AlgebraOfFunctions/22IntAlg_07_functOperation.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-combining-WW3">
+  <exercise xml:id="ez-changing-combining-WW3" label="Library__CollegeOfIdaho__setAlgebra_02_02_AlgebraOfFunctions__22IntAlg_09_functOperation">
     <webwork source="Library/CollegeOfIdaho/setAlgebra_02_02_AlgebraOfFunctions/22IntAlg_09_functOperation.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-combining-WW4">
+  <exercise xml:id="ez-changing-combining-WW4" label="Library__CollegeOfIdaho__setAlgebra_02_02_AlgebraOfFunctions__22IntAlg_10_functOperation">
     <webwork source="Library/CollegeOfIdaho/setAlgebra_02_02_AlgebraOfFunctions/22IntAlg_10_functOperation.pg"/>
   </exercise>  
 
-  <exercise xml:id="ez-changing-combining-WW5">
+  <exercise xml:id="ez-changing-combining-WW5" label="Library__CollegeOfIdaho__setAlgebra_02_02_AlgebraOfFunctions__22IntAlg_12_functOperation">
     <webwork source="Library/CollegeOfIdaho/setAlgebra_02_02_AlgebraOfFunctions/22IntAlg_12_functOperation.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-combining-WW6">
+  <exercise xml:id="ez-changing-combining-WW6" label="Library__CollegeOfIdaho__setAlgebra_02_02_AlgebraOfFunctions__22IntAlg_13_functOperation">
     <webwork source="Library/CollegeOfIdaho/setAlgebra_02_02_AlgebraOfFunctions/22IntAlg_13_functOperation.pg"/>
   </exercise>
 
 
 <!--
 
-  <exercise xml:id="ez-changing-combining-WW8">
+  <exercise xml:id="ez-changing-combining-WW8" label="Library__LoyolaChicago__Precalc__Chap2Sec3__Q10">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec3/Q10.pg" />
   </exercise>
 -->

--- a/source/exercises/ez-changing-composite.xml
+++ b/source/exercises/ez-changing-composite.xml
@@ -13,42 +13,42 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-changing-composite">
  
-  <exercise xml:id="ez-changing-composite-WW1">
+  <exercise xml:id="ez-changing-composite-WW1" label="Library__LoyolaChicago__Precalc__Chap2Sec4__Connally3-2-4-01-Composition-inverse">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec4/Connally3-2-4-01-Composition-inverse.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-composite-WW2">
+  <exercise xml:id="ez-changing-composite-WW2" label="Library__LoyolaChicago__Precalc__Chap2Sec4__Connally3-2-4-04-Composition-inverse">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec4/Connally3-2-4-04-Composition-inverse.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-composite-WW3">
+  <exercise xml:id="ez-changing-composite-WW3" label="Library__LoyolaChicago__Precalc__Chap2Sec4__Connally3-2-4-33-Composition-inverse">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec4/Connally3-2-4-33-Composition-inverse.pg"/>
   </exercise>
 
   <!-- no statement tag
-  <exercise xml:id="ez-changing-composite-WW4">
+  <exercise xml:id="ez-changing-composite-WW4" label="Library__Rochester__setAlgebra15Functions__s0_1_2a">
     <webwork source="Library/Rochester/setAlgebra15Functions/s0_1_2a.pg" />
   </exercise>
-  <exercise xml:id="ez-changing-composite-WW5">
+  <exercise xml:id="ez-changing-composite-WW5" label="Library__Rochester__setAlgebra15Functions__srw2_1_29">
     <webwork source="Library/Rochester/setAlgebra15Functions/srw2_1_29.pg" />
   </exercise>  
   -->
   
-  <exercise xml:id="ez-changing-composite-WW6">
+  <exercise xml:id="ez-changing-composite-WW6" label="Library__Rochester__setAlgebra17FunComposition__beth3algfun">
     <webwork source="Library/Rochester/setAlgebra17FunComposition/beth3algfun.pg"/>
   </exercise> 
-  <exercise xml:id="ez-changing-composite-WW7">
+  <exercise xml:id="ez-changing-composite-WW7" label="Library__Rochester__setAlgebra17FunComposition__c0s1p9">
     <webwork source="Library/Rochester/setAlgebra17FunComposition/c0s1p9.pg"/>
   </exercise> 
-  <exercise xml:id="ez-changing-composite-WW8">
+  <exercise xml:id="ez-changing-composite-WW8" label="Library__Rochester__setAlgebra17FunComposition__faris1">
     <webwork source="Library/Rochester/setAlgebra17FunComposition/faris1.pg"/>
   </exercise> 
 
 <!-- the image shows in HTML but not PDF
-  <exercise xml:id="ez-changing-composite-WW9">
+  <exercise xml:id="ez-changing-composite-WW9" label="Library__Rochester__setAlgebra17FunComposition__srw2_8_23">
     <webwork source="Library/Rochester/setAlgebra17FunComposition/srw2_8_23.pg" />
   </exercise> 
 --> 
   
-  <exercise xml:id="ez-changing-composite-WW10">
+  <exercise xml:id="ez-changing-composite-WW10" label="Library__Rochester__setAlgebra17FunComposition__ur_fn_2_6">
     <webwork source="Library/Rochester/setAlgebra17FunComposition/ur_fn_2_6.pg"/>
   </exercise> 
 

--- a/source/exercises/ez-changing-functions.xml
+++ b/source/exercises/ez-changing-functions.xml
@@ -14,28 +14,28 @@
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-changing-functions">
 
 <!-- does not have a statement tag
-  <exercise xml:id="ez-changing-functions-WW0">
+  <exercise xml:id="ez-changing-functions-WW0" label="Library__Rochester__setAlgebra16FunctionGraphs__c0s1p3__c0s1p3">
     <webwork source="Library/Rochester/setAlgebra16FunctionGraphs/c0s1p3/c0s1p3.pg" />
   </exercise>
  
 -->  
 
-  <exercise xml:id="ez-changing-functions-WW1">
+  <exercise xml:id="ez-changing-functions-WW1" label="Library__LoyolaChicago__Precalc__Chap1Sec1__Q01">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec1/Q01.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-functions-WW2">
+  <exercise xml:id="ez-changing-functions-WW2" label="Library__LoyolaChicago__Precalc__Chap1Sec1__Q24">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec1/Q24.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-functions-WW3">
+  <exercise xml:id="ez-changing-functions-WW3" label="Library__LoyolaChicago__Precalc__Chap1Sec1__Q19">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec1/Q19.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-functions-WW4">
+  <exercise xml:id="ez-changing-functions-WW4" label="Library__LoyolaChicago__Precalc__Chap2Sec1__Connally3-2-1-25-Input-and-output">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec1/Connally3-2-1-25-Input-and-output.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-functions-WW5">
+  <exercise xml:id="ez-changing-functions-WW5" label="Library__LoyolaChicago__Precalc__Chap2Sec1__Q20">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec1/Q20.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-functions-WW6">
+  <exercise xml:id="ez-changing-functions-WW6" label="Library__maCalcDB__setAlgebra15Functions__jay4">
     <webwork source="Library/maCalcDB/setAlgebra15Functions/jay4.pg"/>
   </exercise>
 

--- a/source/exercises/ez-changing-inverse.xml
+++ b/source/exercises/ez-changing-inverse.xml
@@ -13,27 +13,27 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-changing-inverse">
 
-  <exercise xml:id="ez-changing-inverse-WW1">
+  <exercise xml:id="ez-changing-inverse-WW1" label="Library__LoyolaChicago__Precalc__Chap2Sec4__Connally3-2-4-13-Composition-inverse">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec4/Connally3-2-4-13-Composition-inverse.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-inverse-WW2">
+  <exercise xml:id="ez-changing-inverse-WW2" label="Library__LoyolaChicago__Precalc__Chap2Sec4__Connally3-2-4-15-Composition-inverse">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec4/Connally3-2-4-15-Composition-inverse.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-inverse-WW3">
+  <exercise xml:id="ez-changing-inverse-WW3" label="Library__LoyolaChicago__Precalc__Chap2Sec4__Connally3-2-4-28-Composition-inverse">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec4/Connally3-2-4-28-Composition-inverse.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-inverse-WW4">
+  <exercise xml:id="ez-changing-inverse-WW4" label="Library__LoyolaChicago__Precalc__Chap2Sec4__Connally3-2-4-31-Composition-inverse">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec4/Connally3-2-4-31-Composition-inverse.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-inverse-WW5">
+  <exercise xml:id="ez-changing-inverse-WW5" label="Library__LoyolaChicago__Precalc__Chap2Sec4__Q16">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec4/Q16.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-inverse-WW7">
+  <exercise xml:id="ez-changing-inverse-WW7" label="Library__LoyolaChicago__Precalc__Chap2Sec4__Q32">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec4/Q32.pg"/>
   </exercise>
 

--- a/source/exercises/ez-changing-linear.xml
+++ b/source/exercises/ez-changing-linear.xml
@@ -13,29 +13,29 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-changing-linear">
 
-  <exercise xml:id="ez-changing-linear-WW1">
+  <exercise xml:id="ez-changing-linear-WW1" label="Library__Michigan__Chap1Sec2__Q05">
     <webwork source="Library/Michigan/Chap1Sec2/Q05.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-linear-WW2">
+  <exercise xml:id="ez-changing-linear-WW2" label="Library__LoyolaChicago__Precalc__Chap2Review__Q36">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Review/Q36.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-linear-WW3">
+  <exercise xml:id="ez-changing-linear-WW3" label="Library__LoyolaChicago__Precalc__Chap1Sec3__Q25">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec3/Q25.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-linear-WW4">
+  <exercise xml:id="ez-changing-linear-WW4" label="Library__LoyolaChicago__Precalc__Chap1Sec4__Q28">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec4/Q28.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-linear-WW5">
+  <exercise xml:id="ez-changing-linear-WW5" label="Library__LoyolaChicago__Precalc__Chap1Sec4__Q35">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec4/Q35.pg"/>
   </exercise>
 
 
 <!-- THIS ONE DOESN'T
-  <exercise xml:id="ez-changing-linear-WW6">
+  <exercise xml:id="ez-changing-linear-WW6" label="Library__Michigan__skills_questions__topic_point_slope_line__prob02">
     <webwork source="Library/Michigan/skills_questions/topic_point_slope_line/prob02.pg" />
   </exercise>
 -->

--- a/source/exercises/ez-changing-quadratic.xml
+++ b/source/exercises/ez-changing-quadratic.xml
@@ -16,7 +16,7 @@
   <exercise xml:id="ez-changing-quadratic-WW1" label="Library__Rochester__setAlgebra20QuadraticFun__lh3-1_19-20">
     <webwork source="Library/Rochester/setAlgebra20QuadraticFun/lh3-1_19-20.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-quadratic-WW2" label="Library__Rochester__setAlgebra20QuadraticFun__lh3-1_1-3">
+  <exercise xml:id="ez-changing-quadratic-WW2" label="Library__Rochester__setAlgebra20QuadraticFun__lh3-1_1-3-1">
     <webwork source="Library/Rochester/setAlgebra20QuadraticFun/lh3-1_1-3.pg"/>
   </exercise>
   <exercise xml:id="ez-changing-quadratic-WW3" label="Library__LoyolaChicago__Precalc__Chap2Sec6__Q22a">
@@ -48,7 +48,7 @@
   <exercise xml:id="ez-quadratic-find-formula">
     <statement>
       <p>
-        Two quadratic functions, <m>f</m> and <m>g</m>, are determined by their respective graphs in <xref ref="F-ez-quadratic-find-formula">Figure</xref>. 
+        Two quadratic functions, <m>f</m> and <m>g</m>, are determined by their respective graphs in <xref ref="F-ez-quadratic-find-formula">Figure</xref>.
       </p>
 
       <figure xml:id="F-ez-quadratic-find-formula">
@@ -109,7 +109,7 @@
           </li>
           <li>
             <p>
-              Does <m>f</m> have <m>0</m>, <m>1</m>, or <m>2</m> <m>x</m>-intercepts?  Explain, and determine the location(s) of any <m>x</m>-intercept(s) that exist. 
+              Does <m>f</m> have <m>0</m>, <m>1</m>, or <m>2</m> <m>x</m>-intercepts?  Explain, and determine the location(s) of any <m>x</m>-intercept(s) that exist.
             </p>
           </li>
           <li>
@@ -150,7 +150,7 @@
                       <cell/>
                     </row>
                   </tabular>
-                </table>  
+                </table>
                 <table xml:id="T-ez-quadratic-AVs">
                   <title>Average rates of change for <m>f</m> on select intervals.</title>
                   <tabular>
@@ -205,7 +205,7 @@
   <exercise xml:id="ez-quadratic-water-balloon">
     <statement>
       <p>
-        A water balloon is tossed vertically from a window on the fourth floor of a dormitory from an initial height of <m>56.3</m> feet.  A person two floors above observes the balloon reach its highest point <m>1.2</m> seconds after being launched.  
+        A water balloon is tossed vertically from a window on the fourth floor of a dormitory from an initial height of <m>56.3</m> feet.  A person two floors above observes the balloon reach its highest point <m>1.2</m> seconds after being launched.
       </p>
 
       <p>
@@ -243,6 +243,6 @@
         Exercise Solution
       </p>
     </solution>
-  </exercise>  
+  </exercise>
 
 </exercises>

--- a/source/exercises/ez-changing-quadratic.xml
+++ b/source/exercises/ez-changing-quadratic.xml
@@ -13,33 +13,33 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-changing-quadratic">
 
-  <exercise xml:id="ez-changing-quadratic-WW1">
+  <exercise xml:id="ez-changing-quadratic-WW1" label="Library__Rochester__setAlgebra20QuadraticFun__lh3-1_19-20">
     <webwork source="Library/Rochester/setAlgebra20QuadraticFun/lh3-1_19-20.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-quadratic-WW2">
+  <exercise xml:id="ez-changing-quadratic-WW2" label="Library__Rochester__setAlgebra20QuadraticFun__lh3-1_1-3">
     <webwork source="Library/Rochester/setAlgebra20QuadraticFun/lh3-1_1-3.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-quadratic-WW3">
+  <exercise xml:id="ez-changing-quadratic-WW3" label="Library__LoyolaChicago__Precalc__Chap2Sec6__Q22a">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec6/Q22a.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-quadratic-WW4">
+  <exercise xml:id="ez-changing-quadratic-WW4" label="Library__LoyolaChicago__Precalc__Chap2Sec6__Q14">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec6/Q14.pg"/>
   </exercise>
-  <exercise xml:id="ez-changing-quadratic-WW5">
+  <exercise xml:id="ez-changing-quadratic-WW5" label="Library__ASU-topics__setRateChange__s1_1_5">
     <webwork source="Library/ASU-topics/setRateChange/s1_1_5.pg"/>
   </exercise>
 
 
 <!--  THESE ONES DON'T
-  <exercise xml:id="ez-changing-quadratic-WW5">
+  <exercise xml:id="ez-changing-quadratic-WW5" label="Library__LoyolaChicago__Precalc__Chap2Sec6__Q10">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec6/Q10.pg" />
   </exercise>
 
-  <exercise xml:id="ez-changing-quadratic-WW6">
+  <exercise xml:id="ez-changing-quadratic-WW6" label="Library__LoyolaChicago__Precalc__Chap2Sec6__Q30">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec6/Q30.pg" />
   </exercise>
 
-  <exercise xml:id="ez-changing-quadratic-WW7">
+  <exercise xml:id="ez-changing-quadratic-WW7" label="Library__LoyolaChicago__Precalc__Chap2Sec1__Q34">
     <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec1/Q34.pg" />
   </exercise>
 -->

--- a/source/exercises/ez-changing-tandem.xml
+++ b/source/exercises/ez-changing-tandem.xml
@@ -14,13 +14,13 @@
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-changing-tandem">
 
 <!-- THIS ONE WORKS -->
-  <exercise xml:id="ez-changing-tandem-WW0">
+  <exercise xml:id="ez-changing-tandem-WW0" label="Library__LoyolaChicago__Precalc__Chap1Review__Q37">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Review/Q37.pg"/>
   </exercise>
 
 
 <!-- doesn't render in PDF bc no statement tag
-  <exercise xml:id="ez-changing-tandem-WW1">
+  <exercise xml:id="ez-changing-tandem-WW1" label="Library__Rochester__setAlgebra16FunctionGraphs__c0s1p8__c0s1p8">
     <webwork source="Library/Rochester/setAlgebra16FunctionGraphs/c0s1p8/c0s1p8.pg" />
   </exercise>
 -->

--- a/source/exercises/ez-changing-transformations.xml
+++ b/source/exercises/ez-changing-transformations.xml
@@ -13,36 +13,36 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-changing-transformations">
 
-  <exercise xml:id="ez-changing-transformations-WW1">
+  <exercise xml:id="ez-changing-transformations-WW1" label="Library__Rochester__setAlgebra19FunTransforms__p1">
     <webwork source="Library/Rochester/setAlgebra19FunTransforms/p1.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-transformations-WW2">
+  <exercise xml:id="ez-changing-transformations-WW2" label="Library__Rochester__setAlgebra19FunTransforms__ptransf2">
     <webwork source="Library/Rochester/setAlgebra19FunTransforms/ptransf2.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-transformations-WW3">
+  <exercise xml:id="ez-changing-transformations-WW3" label="Library__Rochester__setAlgebra20QuadraticFun__lh3-1_1-3">
     <webwork source="Library/Rochester/setAlgebra20QuadraticFun/lh3-1_1-3.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-transformations-WW4">
+  <exercise xml:id="ez-changing-transformations-WW4" label="Library__Michigan__Chap1Sec3__Q05">
     <webwork source="Library/Michigan/Chap1Sec3/Q05.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-transformations-WW6">
+  <exercise xml:id="ez-changing-transformations-WW6" label="Library__LoyolaChicago__Precalc__Chap5Sec1__Q09">
     <webwork source="Library/LoyolaChicago/Precalc/Chap5Sec1/Q09.pg"/>
   </exercise>  
 
 <!--  THESE ONES DON'T
-  <exercise xml:id="ez-changing-transformations-WW5">
+  <exercise xml:id="ez-changing-transformations-WW5" label="Library__LoyolaChicago__Precalc__Chap5Sec1__Q18">
     <webwork source="Library/LoyolaChicago/Precalc/Chap5Sec1/Q18.pg" />
   </exercise>
 
-  <exercise xml:id="ez-changing-transformations-WW5">
+  <exercise xml:id="ez-changing-transformations-WW5" label="Library__LoyolaChicago__Precalc__Chap5Sec1__Q08">
     <webwork source="Library/LoyolaChicago/Precalc/Chap5Sec1/Q08.pg" />
   </exercise>
 
-  <exercise xml:id="ez-changing-transformations-WW6">
+  <exercise xml:id="ez-changing-transformations-WW6" label="Library__Rochester__setAlgebra19FunTransforms__beth1algfun">
     <webwork source="Library/Rochester/setAlgebra19FunTransforms/beth1algfun.pg" />
   </exercise>
 -->

--- a/source/exercises/ez-changing-transformations.xml
+++ b/source/exercises/ez-changing-transformations.xml
@@ -21,7 +21,7 @@
     <webwork source="Library/Rochester/setAlgebra19FunTransforms/ptransf2.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-changing-transformations-WW3" label="Library__Rochester__setAlgebra20QuadraticFun__lh3-1_1-3">
+  <exercise xml:id="ez-changing-transformations-WW3" label="Library__Rochester__setAlgebra20QuadraticFun__lh3-1_1-3-2">
     <webwork source="Library/Rochester/setAlgebra20QuadraticFun/lh3-1_1-3.pg"/>
   </exercise>
 
@@ -31,7 +31,7 @@
 
   <exercise xml:id="ez-changing-transformations-WW6" label="Library__LoyolaChicago__Precalc__Chap5Sec1__Q09">
     <webwork source="Library/LoyolaChicago/Precalc/Chap5Sec1/Q09.pg"/>
-  </exercise>  
+  </exercise>
 
 <!--  THESE ONES DON'T
   <exercise xml:id="ez-changing-transformations-WW5" label="Library__LoyolaChicago__Precalc__Chap5Sec1__Q18">

--- a/source/exercises/ez-circular-sine-cosine.xml
+++ b/source/exercises/ez-circular-sine-cosine.xml
@@ -13,32 +13,32 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-circular-sine-cosine">
 
-  <exercise xml:id="ez-circular-sine-cosine-WW1">
+  <exercise xml:id="ez-circular-sine-cosine-WW1" label="Library__LoyolaChicago__Precalc__Chap6Sec4__Q14">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec4/Q14.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-circular-sine-cosine-WW6">
+  <exercise xml:id="ez-circular-sine-cosine-WW6" label="Library__NAU__setSineCosine__SinCosDeg">
     <webwork source="Library/NAU/setSineCosine/SinCosDeg.pg"/>
   </exercise>
-  <exercise xml:id="ez-circular-sine-cosine-WW7">
+  <exercise xml:id="ez-circular-sine-cosine-WW7" label="Library__NAU__setSineCosine__SinCosPosNeg">
     <webwork source="Library/NAU/setSineCosine/SinCosPosNeg.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-circular-sine-cosine-WW4">
+  <exercise xml:id="ez-circular-sine-cosine-WW4" label="Library__LoyolaChicago__Precalc__Chap6Sec4__Q30">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec4/Q30.pg"/>
   </exercise>
 
 
 <!--
-  <exercise xml:id="ez-circular-sine-cosine-WW2">
+  <exercise xml:id="ez-circular-sine-cosine-WW2" label="Library__LoyolaChicago__Precalc__Chap6Sec4__Q18">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec4/Q18.pg" />
   </exercise>
 
-  <exercise xml:id="ez-circular-sine-cosine-WW3">
+  <exercise xml:id="ez-circular-sine-cosine-WW3" label="Library__LoyolaChicago__Precalc__Chap6Sec4__Q20">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec4/Q20.pg" />
   </exercise>
 
-  <exercise xml:id="ez-circular-sine-cosine-WW5">
+  <exercise xml:id="ez-circular-sine-cosine-WW5" label="Library__LoyolaChicago__Precalc__Chap6Sec2__Q01">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec2/Q01.pg" />
   </exercise>
 

--- a/source/exercises/ez-circular-sinusoidal.xml
+++ b/source/exercises/ez-circular-sinusoidal.xml
@@ -14,22 +14,22 @@
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-circular-sinusoidal">
   
 
-  <exercise xml:id="ez-circular-sinusoidal-WW1">
+  <exercise xml:id="ez-circular-sinusoidal-WW1" label="Library__LoyolaChicago__Precalc__Chap6Review__Q18">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Review/Q18.pg"/>
   </exercise>
-  <exercise xml:id="ez-circular-sinusoidal-WW2">
+  <exercise xml:id="ez-circular-sinusoidal-WW2" label="Library__LoyolaChicago__Precalc__Chap6Review__Q20">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Review/Q20.pg"/>
   </exercise>
-  <exercise xml:id="ez-circular-sinusoidal-WW3">
+  <exercise xml:id="ez-circular-sinusoidal-WW3" label="Library__LoyolaChicago__Precalc__Chap6Review__Q28">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Review/Q28.pg"/>
   </exercise>
-  <exercise xml:id="ez-circular-sinusoidal-WW4">
+  <exercise xml:id="ez-circular-sinusoidal-WW4" label="Library__LoyolaChicago__Precalc__Chap6Sec5__Q12">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec5/Q12.pg"/>
   </exercise>
-  <exercise xml:id="ez-circular-sinusoidal-WW5">
+  <exercise xml:id="ez-circular-sinusoidal-WW5" label="Library__LoyolaChicago__Precalc__Chap6Sec5__Q18">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec5/Q18.pg"/>
   </exercise>
-  <exercise xml:id="ez-circular-sinusoidal-WW6">
+  <exercise xml:id="ez-circular-sinusoidal-WW6" label="Library__LoyolaChicago__Precalc__Chap6Sec5__Q28">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec5/Q28.pg"/>
   </exercise>
 

--- a/source/exercises/ez-circular-traversing.xml
+++ b/source/exercises/ez-circular-traversing.xml
@@ -13,27 +13,27 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-circular-traversing">
 
-  <exercise xml:id="ez-circular-traversing-WW2">
+  <exercise xml:id="ez-circular-traversing-WW2" label="Library__LoyolaChicago__Precalc__Chap6Sec1__Q12">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec1/Q12.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-circular-traversing-WW3a">
+  <exercise xml:id="ez-circular-traversing-WW3a" label="Library__LoyolaChicago__Precalc__Chap6Sec1__Q16">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec1/Q16.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-circular-traversing-WW4">
+  <exercise xml:id="ez-circular-traversing-WW4" label="Library__LoyolaChicago__Precalc__Chap6Sec1__Q23">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec1/Q23.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-circular-traversing-WW5">
+  <exercise xml:id="ez-circular-traversing-WW5" label="Library__LoyolaChicago__Precalc__Chap6Sec1__Q28">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec1/Q28.pg"/>
   </exercise>
 
 <!-- did not generate valid XML
-  <exercise xml:id="ez-circular-traversing-WW1">
+  <exercise xml:id="ez-circular-traversing-WW1" label="Library__LoyolaChicago__Precalc__Chap6Sec1__Q10">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec1/Q10.pg" />
   </exercise>
-  <exercise xml:id="ez-circular-traversing-WW3">
+  <exercise xml:id="ez-circular-traversing-WW3" label="Library__LoyolaChicago__Precalc__Chap6Sec1__Q20">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec1/Q20.pg" />
   </exercise>
 -->

--- a/source/exercises/ez-circular-unit-circle.xml
+++ b/source/exercises/ez-circular-unit-circle.xml
@@ -13,26 +13,26 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-circular-unit-circle">
 
-  <exercise xml:id="ez-circular-unit-circle-WW8">
+  <exercise xml:id="ez-circular-unit-circle-WW8" label="Library__Rochester__setTrig02FunctionsUnitCircle__srw5_1_11">
     <webwork source="Library/Rochester/setTrig02FunctionsUnitCircle/srw5_1_11.pg"/>
   </exercise>
-  <exercise xml:id="ez-circular-unit-circle-WW1">
+  <exercise xml:id="ez-circular-unit-circle-WW1" label="Library__LoyolaChicago__Precalc__Chap6Sec3__Q02">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec3/Q02.pg"/>
   </exercise>
-  <exercise xml:id="ez-circular-unit-circle-WW2">
+  <exercise xml:id="ez-circular-unit-circle-WW2" label="Library__LoyolaChicago__Precalc__Chap6Sec3__Q04">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec3/Q04.pg"/>
   </exercise>
-  <exercise xml:id="ez-circular-unit-circle-WW3">
+  <exercise xml:id="ez-circular-unit-circle-WW3" label="Library__LoyolaChicago__Precalc__Chap6Sec3__Q20">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec3/Q20.pg"/>
   </exercise>
-  <exercise xml:id="ez-circular-unit-circle-WW4">
+  <exercise xml:id="ez-circular-unit-circle-WW4" label="Library__LoyolaChicago__Precalc__Chap6Sec3__Q26">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec3/Q26.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-circular-unit-circle-WW5">
+  <exercise xml:id="ez-circular-unit-circle-WW5" label="Library__LoyolaChicago__Precalc__Chap6Review__Q13">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Review/Q13.pg"/>
   </exercise>
-  <exercise xml:id="ez-circular-unit-circle-WW6">
+  <exercise xml:id="ez-circular-unit-circle-WW6" label="Library__LoyolaChicago__Precalc__Chap6Sec3__Q09">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec3/Q09.pg"/>
   </exercise>
 

--- a/source/exercises/ez-exp-e.xml
+++ b/source/exercises/ez-exp-e.xml
@@ -14,32 +14,32 @@
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-exp-e">
 
 <!--
-  <exercise xml:id="ez-exp-e-WW1">
+  <exercise xml:id="ez-exp-e-WW1" label="Library__LoyolaChicago__Precalc__Chap3Sec4__Q04">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec4/Q04.pg" />
   </exercise>
-  <exercise xml:id="ez-exp-e-WW2">
+  <exercise xml:id="ez-exp-e-WW2" label="Library__LoyolaChicago__Precalc__Chap3Sec4__Q06">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec4/Q06.pg" />
   </exercise>
 -->
 
-  <exercise xml:id="ez-exp-e-WW0">
+  <exercise xml:id="ez-exp-e-WW0" label="Library__Rochester__setAlgebra28ExpFunctions__sw6_2_27">
     <webwork source="Library/Rochester/setAlgebra28ExpFunctions/sw6_2_27.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-e-WW1">
+  <exercise xml:id="ez-exp-e-WW1" label="Library__Rochester__setAlgebra28ExpFunctions__sw6_2_3">
     <webwork source="Library/Rochester/setAlgebra28ExpFunctions/sw6_2_3.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-e-WW2">
+  <exercise xml:id="ez-exp-e-WW2" label="Library__Rochester__setAlgebra28ExpFunctions__sw6_2_5">
     <webwork source="Library/Rochester/setAlgebra28ExpFunctions/sw6_2_5.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-e-WW3">
+  <exercise xml:id="ez-exp-e-WW3" label="Library__LoyolaChicago__Precalc__Chap3Sec4__Q12">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec4/Q12.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-e-WW4">
+  <exercise xml:id="ez-exp-e-WW4" label="Library__LoyolaChicago__Precalc__Chap3Sec4__Q13">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec4/Q13.pg"/>
   </exercise>
 
 <!--  
-  <exercise xml:id="ez-exp-e-WW5">
+  <exercise xml:id="ez-exp-e-WW5" label="Library__LoyolaChicago__Precalc__Chap3Sec4__Q24">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec4/Q24.pg" />
   </exercise>
 

--- a/source/exercises/ez-exp-growth.xml
+++ b/source/exercises/ez-exp-growth.xml
@@ -13,39 +13,39 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-exp-growth">
 
-  <exercise xml:id="ez-exp-growth-WW1">
+  <exercise xml:id="ez-exp-growth-WW1" label="Library__LoyolaChicago__Precalc__Chap3Sec1__Connally3-3-1-12-Exponential-functions">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec1/Connally3-3-1-12-Exponential-functions.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-growth-WW2">
+  <exercise xml:id="ez-exp-growth-WW2" label="Library__LoyolaChicago__Precalc__Chap3Sec1__Connally3-3-1-19-Exponential-functions">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec1/Connally3-3-1-19-Exponential-functions.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-growth-WW3">
+  <exercise xml:id="ez-exp-growth-WW3" label="Library__LoyolaChicago__Precalc__Chap3Sec1__Connally3-3-1-27-Exponential-functions">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec1/Connally3-3-1-27-Exponential-functions.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-growth-WW4">
+  <exercise xml:id="ez-exp-growth-WW4" label="Library__LoyolaChicago__Precalc__Chap3Sec1__Connally3-3-1-28-Exponential-functions">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec1/Connally3-3-1-28-Exponential-functions.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-exp-growth-WW6">
+  <exercise xml:id="ez-exp-growth-WW6" label="Library__LoyolaChicago__Precalc__Chap3Sec1__Q16">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec1/Q16.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-exp-growth-WW8">
+  <exercise xml:id="ez-exp-growth-WW8" label="Library__LoyolaChicago__Precalc__Chap3Sec2__Connally3-3-2-08-Exponential-vs-linear">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec2/Connally3-3-2-08-Exponential-vs-linear.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-exp-growth-WW10">
+  <exercise xml:id="ez-exp-growth-WW10" label="Library__LoyolaChicago__Precalc__Chap3Sec2__Q02">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec2/Q02.pg"/>
   </exercise>
 
 <!--
-  <exercise xml:id="ez-exp-growth-WW5">
+  <exercise xml:id="ez-exp-growth-WW5" label="Library__LoyolaChicago__Precalc__Chap3Sec1__Q15">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec1/Q15.pg" />
   </exercise>
-  <exercise xml:id="ez-exp-growth-WW7">
+  <exercise xml:id="ez-exp-growth-WW7" label="Library__LoyolaChicago__Precalc__Chap3Sec1__Q41">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec1/Q41.pg" />
   </exercise>
-  <exercise xml:id="ez-exp-growth-WW9">
+  <exercise xml:id="ez-exp-growth-WW9" label="Library__LoyolaChicago__Precalc__Chap3Sec1__Connally3-3-2-31-Exponential-vs-linear">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec1/Connally3-3-2-31-Exponential-vs-linear.pg" />
   </exercise>
 -->

--- a/source/exercises/ez-exp-log-properties.xml
+++ b/source/exercises/ez-exp-log-properties.xml
@@ -13,33 +13,33 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-exp-log-properties">
   
-  <exercise xml:id="ez-exp-log-properties-WW1">
+  <exercise xml:id="ez-exp-log-properties-WW1" label="Library__Rochester__setAlgebra30LogExpEqns__problem9">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/problem9.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-log-properties-WW2">
+  <exercise xml:id="ez-exp-log-properties-WW2" label="Library__Rochester__setAlgebra30LogExpEqns__problem11">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/problem11.pg"/>
   </exercise>
 <!--  
-  <exercise xml:id="ez-exp-log-properties-WW3">
+  <exercise xml:id="ez-exp-log-properties-WW3" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_3_48">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_3_48.pg" />
   </exercise>
-  <exercise xml:id="ez-exp-log-properties-WW7">
+  <exercise xml:id="ez-exp-log-properties-WW7" label="Library__Rochester__setAlgebra31LogExpEqns__srw4_2_1">
     <webwork source="Library/Rochester/setAlgebra31LogExpEqns/srw4_2_1.pg" />
   </exercise>
-  <exercise xml:id="ez-exp-log-properties-WW8">
+  <exercise xml:id="ez-exp-log-properties-WW8" label="Library__Rochester__setAlgebra31LogExpEqns__ur_le_2_11">
     <webwork source="Library/Rochester/setAlgebra31LogExpEqns/ur_le_2_11.pg" />
   </exercise>
-  <exercise xml:id="ez-exp-log-properties-WW9">
+  <exercise xml:id="ez-exp-log-properties-WW9" label="Library__Rochester__setAlgebra31LogExpEqns__ur_le_2_12">
     <webwork source="Library/Rochester/setAlgebra31LogExpEqns/ur_le_2_12.pg" />
   </exercise>  
 -->  
-  <exercise xml:id="ez-exp-log-properties-WW4">
+  <exercise xml:id="ez-exp-log-properties-WW4" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_11">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_4_11.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-log-properties-WW5">
+  <exercise xml:id="ez-exp-log-properties-WW5" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_25">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_4_25.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-log-properties-WW6">
+  <exercise xml:id="ez-exp-log-properties-WW6" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_41">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_4_41.pg"/>
   </exercise>
 

--- a/source/exercises/ez-exp-log-properties.xml
+++ b/source/exercises/ez-exp-log-properties.xml
@@ -12,14 +12,14 @@
 <!-- their respective owners.                                              -->
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-exp-log-properties">
-  
+
   <exercise xml:id="ez-exp-log-properties-WW1" label="Library__Rochester__setAlgebra30LogExpEqns__problem9">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/problem9.pg"/>
   </exercise>
   <exercise xml:id="ez-exp-log-properties-WW2" label="Library__Rochester__setAlgebra30LogExpEqns__problem11">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/problem11.pg"/>
   </exercise>
-<!--  
+<!--
   <exercise xml:id="ez-exp-log-properties-WW3" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_3_48">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_3_48.pg" />
   </exercise>
@@ -31,15 +31,15 @@
   </exercise>
   <exercise xml:id="ez-exp-log-properties-WW9" label="Library__Rochester__setAlgebra31LogExpEqns__ur_le_2_12">
     <webwork source="Library/Rochester/setAlgebra31LogExpEqns/ur_le_2_12.pg" />
-  </exercise>  
--->  
+  </exercise>
+-->
   <exercise xml:id="ez-exp-log-properties-WW4" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_11">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_4_11.pg"/>
   </exercise>
   <exercise xml:id="ez-exp-log-properties-WW5" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_25">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_4_25.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-log-properties-WW6" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_41">
+  <exercise xml:id="ez-exp-log-properties-WW6" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_41-2">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_4_41.pg"/>
   </exercise>
 
@@ -128,7 +128,7 @@
         Exercise Solution
       </p>
     </solution>
-  </exercise> 
+  </exercise>
 
   <exercise xml:id="ez-exp-log-properties-Golden-Rule">
     <statement>
@@ -184,5 +184,5 @@
       </p>
     </solution>
   </exercise>
-   
+
 </exercises>

--- a/source/exercises/ez-exp-log.xml
+++ b/source/exercises/ez-exp-log.xml
@@ -13,24 +13,24 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-exp-log">
 
-  <exercise xml:id="ez-exp-log-WW1">
+  <exercise xml:id="ez-exp-log-WW1" label="Library__Rochester__setAlgebra29LogFunctions__srw4_2_5">
     <webwork source="Library/Rochester/setAlgebra29LogFunctions/srw4_2_5.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-log-WW2">
+  <exercise xml:id="ez-exp-log-WW2" label="Library__Rochester__setAlgebra29LogFunctions__problem4">
     <webwork source="Library/Rochester/setAlgebra29LogFunctions/problem4.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-log-WW3">
+  <exercise xml:id="ez-exp-log-WW3" label="Library__Rochester__setAlgebra30LogExpEqns__beth2logfun">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/beth2logfun.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-log-WW4">
+  <exercise xml:id="ez-exp-log-WW4" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_17">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_4_17.pg"/>
   </exercise>
 <!--  
-  <exercise xml:id="ez-exp-log-WW5">
+  <exercise xml:id="ez-exp-log-WW5" label="Library__Michigan__skills_questions__topic_solving_exp_log__prob01">
     <webwork source="Library/Michigan/skills_questions/topic_solving_exp_log/prob01.pg" />
   </exercise>
 -->  
-  <exercise xml:id="ez-exp-log-WW6">
+  <exercise xml:id="ez-exp-log-WW6" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_41">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_4_41.pg"/>
   </exercise>
 

--- a/source/exercises/ez-exp-log.xml
+++ b/source/exercises/ez-exp-log.xml
@@ -25,12 +25,12 @@
   <exercise xml:id="ez-exp-log-WW4" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_17">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_4_17.pg"/>
   </exercise>
-<!--  
+<!--
   <exercise xml:id="ez-exp-log-WW5" label="Library__Michigan__skills_questions__topic_solving_exp_log__prob01">
     <webwork source="Library/Michigan/skills_questions/topic_solving_exp_log/prob01.pg" />
   </exercise>
--->  
-  <exercise xml:id="ez-exp-log-WW6" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_41">
+-->
+  <exercise xml:id="ez-exp-log-WW6" label="Library__Rochester__setAlgebra30LogExpEqns__srw4_4_41-1">
     <webwork source="Library/Rochester/setAlgebra30LogExpEqns/srw4_4_41.pg"/>
   </exercise>
 

--- a/source/exercises/ez-exp-modeling.xml
+++ b/source/exercises/ez-exp-modeling.xml
@@ -13,17 +13,17 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-exp-modeling">
 <!--
-  <exercise xml:id="ez-exp-modeling-WW1">
+  <exercise xml:id="ez-exp-modeling-WW1" label="Library__LoyolaChicago__Precalc__Chap3Sec1__Q15">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec1/Q15.pg" />
   </exercise>
 -->  
-  <exercise xml:id="ez-exp-modeling-WW2">
+  <exercise xml:id="ez-exp-modeling-WW2" label="Library__LoyolaChicago__Precalc__Chap3Sec3__Q14">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec3/Q14.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-modeling-WW3">
+  <exercise xml:id="ez-exp-modeling-WW3" label="Library__LoyolaChicago__Precalc__Chap3Sec3__Q33">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec3/Q33.pg"/>
   </exercise>
-  <exercise xml:id="ez-exp-modeling-WW4">
+  <exercise xml:id="ez-exp-modeling-WW4" label="Library__LoyolaChicago__Precalc__Chap3Sec3__Q22">
     <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec3/Q22.pg"/>
   </exercise>
 

--- a/source/exercises/ez-exp-temp-pop.xml
+++ b/source/exercises/ez-exp-temp-pop.xml
@@ -14,26 +14,26 @@
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-exp-temp-pop">
 
 <!--  
-  <exercise xml:id="ez-exp-temp-pop-WW1">
+  <exercise xml:id="ez-exp-temp-pop-WW1" label="Library__Michigan__skills_questions__topic_solving_exp_log__prob03">
     <webwork source="Library/Michigan/skills_questions/topic_solving_exp_log/prob03.pg" />
   </exercise>
 -->  
-  <exercise xml:id="ez-exp-temp-pop-WW2">
+  <exercise xml:id="ez-exp-temp-pop-WW2" label="Library__Rochester__setDiffEQ5ModelingWith1stOrder__ur_de_5_4">
     <webwork source="Library/Rochester/setDiffEQ5ModelingWith1stOrder/ur_de_5_4.pg"/>
   </exercise>
 <!--  
-  <exercise xml:id="ez-exp-temp-pop-WW3">
+  <exercise xml:id="ez-exp-temp-pop-WW3" label="Library__Rochester__setAlgebra31LogExpApplications__cooling">
     <webwork source="Library/Rochester/setAlgebra31LogExpApplications/cooling.pg" />
   </exercise>
 -->
-  <exercise xml:id="ez-exp-temp-pop-WW4">
+  <exercise xml:id="ez-exp-temp-pop-WW4" label="Library__Michigan__Chap11Sec7__Q09">
     <webwork source="Library/Michigan/Chap11Sec7/Q09.pg"/>
   </exercise>
 
 <p>In <xref ref="ez-exp-temp-pop-WW5">Exercise</xref> below, use the following structure/formula for <m>N(t)</m>: <m>N(t)=\frac{L}{1+Ab^{-kt}}</m>.  In particular, note that when the instructions say <q>find <m>A</m></q>, this use of <q><m>A</m></q> is not in reference to carrying capacity.</p>
 
 
-  <exercise xml:id="ez-exp-temp-pop-WW5">
+  <exercise xml:id="ez-exp-temp-pop-WW5" label="Library__Rochester__setAlgebra31LogExpApplications__infection1">
     <webwork source="Library/Rochester/setAlgebra31LogExpApplications/infection1.pg"/>
   </exercise>
 

--- a/source/exercises/ez-poly-infty.xml
+++ b/source/exercises/ez-poly-infty.xml
@@ -14,13 +14,13 @@
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-poly-infty">
   
 
-  <exercise xml:id="ez-poly-infty-WW1">
+  <exercise xml:id="ez-poly-infty-WW1" label="Library__LoyolaChicago__Precalc__Chap9Sec1__Q23">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec1/Q23.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-infty-WW2">
+  <exercise xml:id="ez-poly-infty-WW2" label="Library__LoyolaChicago__Precalc__Chap9Sec1__Q24">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec1/Q24.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-infty-WW3">
+  <exercise xml:id="ez-poly-infty-WW3" label="Library__LoyolaChicago__Precalc__Chap9Sec1__Q01">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec1/Q01.pg"/>
   </exercise>
 

--- a/source/exercises/ez-poly-polynomial-applications.xml
+++ b/source/exercises/ez-poly-polynomial-applications.xml
@@ -14,15 +14,15 @@
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-poly-polynomial-applications">
   
 
-  <exercise xml:id="ez-poly-polynomial-applications-WW1">
+  <exercise xml:id="ez-poly-polynomial-applications-WW1" label="Library__LoyolaChicago__Precalc__Chap9Sec3__Q44">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec3/Q44.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-polynomial-applications-WW2">
+  <exercise xml:id="ez-poly-polynomial-applications-WW2" label="Library__LoyolaChicago__Precalc__Chap9Sec3__Q43">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec3/Q43.pg"/>
   </exercise>
 
 <!--  
-  <exercise xml:id="ez-poly-polynomial-applications-WW3">
+  <exercise xml:id="ez-poly-polynomial-applications-WW3" label="Library__Rochester__setAlgebra23PolynomialZeros__beth1polydiv">
     <webwork source="Library/Rochester/setAlgebra23PolynomialZeros/beth1polydiv.pg" />
   </exercise>
 -->

--- a/source/exercises/ez-poly-polynomials.xml
+++ b/source/exercises/ez-poly-polynomials.xml
@@ -13,32 +13,32 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-poly-polynomials">
   
-  <exercise xml:id="ez-poly-polynomials-WW1">
+  <exercise xml:id="ez-poly-polynomials-WW1" label="Library__LoyolaChicago__Precalc__Chap9Sec2__Q02">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec2/Q02.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-polynomials-WW2">
+  <exercise xml:id="ez-poly-polynomials-WW2" label="Library__LoyolaChicago__Precalc__Chap9Sec2__Q03">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec2/Q03.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-polynomials-WW3">
+  <exercise xml:id="ez-poly-polynomials-WW3" label="Library__LoyolaChicago__Precalc__Chap9Sec2__Q08">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec2/Q08.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-polynomials-WW4">
+  <exercise xml:id="ez-poly-polynomials-WW4" label="Library__LoyolaChicago__Precalc__Chap9Sec2__Q10">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec2/Q10.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-polynomials-WW5">
+  <exercise xml:id="ez-poly-polynomials-WW5" label="Library__LoyolaChicago__Precalc__Chap9Sec2__Q12">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec2/Q12.pg"/>
   </exercise>
 
 <!--  
-  <exercise xml:id="ez-poly-polynomials-WW6">
+  <exercise xml:id="ez-poly-polynomials-WW6" label="Library__LoyolaChicago__Precalc__Chap9Sec2__Q15">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec2/Q15.pg" />
   </exercise>
 -->
 
-  <exercise xml:id="ez-poly-polynomials-WW7">
+  <exercise xml:id="ez-poly-polynomials-WW7" label="Library__LoyolaChicago__Precalc__Chap9Sec2__polynomial-02">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec2/polynomial-02.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-polynomials-WW8">
+  <exercise xml:id="ez-poly-polynomials-WW8" label="Library__LoyolaChicago__Precalc__Chap9Sec2__polynomial-04">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec2/polynomial-04.pg"/>
   </exercise>
 

--- a/source/exercises/ez-poly-rational-features.xml
+++ b/source/exercises/ez-poly-rational-features.xml
@@ -13,27 +13,27 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-poly-rational-features">
   
-  <exercise xml:id="ez-poly-rational-features-WW1">
+  <exercise xml:id="ez-poly-rational-features-WW1" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q24">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q24.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-rational-features-WW2">
+  <exercise xml:id="ez-poly-rational-features-WW2" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q34">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q34.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-rational-features-WW3">
+  <exercise xml:id="ez-poly-rational-features-WW3" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q35">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q35.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-rational-features-WW4">
+  <exercise xml:id="ez-poly-rational-features-WW4" label="Library__LoyolaChicago__Precalc__Chap9Sec4__Q15">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec4/Q15.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-rational-features-WW5">
+  <exercise xml:id="ez-poly-rational-features-WW5" label="Library__LoyolaChicago__Precalc__Chap9Sec4__Q16">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec4/Q16.pg"/>
   </exercise>
 
 <!--  
-  <exercise xml:id="ez-poly-rational-features-WW6">
+  <exercise xml:id="ez-poly-rational-features-WW6" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q17">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q17.pg" />
   </exercise>  
-  <exercise xml:id="ez-poly-rational-features-WW7">
+  <exercise xml:id="ez-poly-rational-features-WW7" label="Library__Rochester__setAlgebra25RationalFun__FindInfo">
     <webwork source="Library/Rochester/setAlgebra25RationalFun/FindInfo.pg" />
   </exercise> 
 -->

--- a/source/exercises/ez-poly-rational-features.xml
+++ b/source/exercises/ez-poly-rational-features.xml
@@ -12,8 +12,8 @@
 <!-- their respective owners.                                              -->
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-poly-rational-features">
-  
-  <exercise xml:id="ez-poly-rational-features-WW1" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q24">
+
+  <exercise xml:id="ez-poly-rational-features-WW1" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q24-2">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q24.pg"/>
   </exercise>
   <exercise xml:id="ez-poly-rational-features-WW2" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q34">
@@ -29,13 +29,13 @@
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec4/Q16.pg"/>
   </exercise>
 
-<!--  
+<!--
   <exercise xml:id="ez-poly-rational-features-WW6" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q17">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q17.pg" />
-  </exercise>  
+  </exercise>
   <exercise xml:id="ez-poly-rational-features-WW7" label="Library__Rochester__setAlgebra25RationalFun__FindInfo">
     <webwork source="Library/Rochester/setAlgebra25RationalFun/FindInfo.pg" />
-  </exercise> 
+  </exercise>
 -->
 
   <exercise xml:id="ez-poly-rational-features-1">

--- a/source/exercises/ez-poly-rational.xml
+++ b/source/exercises/ez-poly-rational.xml
@@ -13,35 +13,35 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-poly-rational">
   
-  <exercise xml:id="ez-poly-rational-WW1">
+  <exercise xml:id="ez-poly-rational-WW1" label="Library__LoyolaChicago__Precalc__Chap9Sec4__Q10">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec4/Q10.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-rational-WW2">
+  <exercise xml:id="ez-poly-rational-WW2" label="Library__LoyolaChicago__Precalc__Chap9Sec4__Q12">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec4/Q12.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-rational-WW3">
+  <exercise xml:id="ez-poly-rational-WW3" label="Library__LoyolaChicago__Precalc__Chap9Sec4__Q13">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec4/Q13.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-rational-WW4">
+  <exercise xml:id="ez-poly-rational-WW4" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q02">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q02.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-rational-WW5">
+  <exercise xml:id="ez-poly-rational-WW5" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q07">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q07.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-rational-WW6">
+  <exercise xml:id="ez-poly-rational-WW6" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q15">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q15.pg"/>
   </exercise>
 
 <!--  
-  <exercise xml:id="ez-poly-rational-WW7">
+  <exercise xml:id="ez-poly-rational-WW7" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q19">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q19.pg" />
   </exercise>
 -->
 
-  <exercise xml:id="ez-poly-rational-WW8">
+  <exercise xml:id="ez-poly-rational-WW8" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q24">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q24.pg"/>
   </exercise>
-  <exercise xml:id="ez-poly-rational-WW9">
+  <exercise xml:id="ez-poly-rational-WW9" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q06">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q06.pg"/>
   </exercise>
 

--- a/source/exercises/ez-poly-rational.xml
+++ b/source/exercises/ez-poly-rational.xml
@@ -12,7 +12,7 @@
 <!-- their respective owners.                                              -->
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-poly-rational">
-  
+
   <exercise xml:id="ez-poly-rational-WW1" label="Library__LoyolaChicago__Precalc__Chap9Sec4__Q10">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec4/Q10.pg"/>
   </exercise>
@@ -32,13 +32,13 @@
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q15.pg"/>
   </exercise>
 
-<!--  
+<!--
   <exercise xml:id="ez-poly-rational-WW7" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q19">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q19.pg" />
   </exercise>
 -->
 
-  <exercise xml:id="ez-poly-rational-WW8" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q24">
+  <exercise xml:id="ez-poly-rational-WW8" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q24-1">
     <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec5/Q24.pg"/>
   </exercise>
   <exercise xml:id="ez-poly-rational-WW9" label="Library__LoyolaChicago__Precalc__Chap9Sec5__Q06">
@@ -139,12 +139,12 @@
         Exercise Solution
       </p>
     </solution>
-  </exercise> 
+  </exercise>
 
   <exercise xml:id="ez-poly-rational-applications-can">
     <statement>
       <p>
-        A cylindrical can is being constructed so that its volume is <m>16</m> cubic inches.  Suppose that material for the lids (the top and bottom) cost $<m>0.11</m> per square inch and material for the <q>side</q> of the can costs $<m>0.07</m> per square inch.  Determine a formula for the total cost of the can as a function of the can's radius.  What is the domain of the function and why?  
+        A cylindrical can is being constructed so that its volume is <m>16</m> cubic inches.  Suppose that material for the lids (the top and bottom) cost $<m>0.11</m> per square inch and material for the <q>side</q> of the can costs $<m>0.07</m> per square inch.  Determine a formula for the total cost of the can as a function of the can's radius.  What is the domain of the function and why?
       </p>
     </statement>
     <hint>
@@ -162,5 +162,5 @@
         Exercise Solution
       </p>
     </solution>
-  </exercise>   
+  </exercise>
 </exercises>

--- a/source/exercises/ez-trig-finding-angles.xml
+++ b/source/exercises/ez-trig-finding-angles.xml
@@ -12,16 +12,16 @@
 <!-- their respective owners.                                              -->
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-trig-finding-angles">
-  
-  <exercise xml:id="ez-trig-finding-angles-WW1" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q24a">
+
+  <exercise xml:id="ez-trig-finding-angles-WW1" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q24a-2">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q24a.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-finding-angles-WW2" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q28">
+  <exercise xml:id="ez-trig-finding-angles-WW2" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q28-2">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q28.pg"/>
   </exercise>
   <exercise xml:id="ez-trig-finding-angles-WW6" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q37">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q37.pg"/>
-  </exercise>   
+  </exercise>
 
 <!--  most of the following fail to have statement tags
 
@@ -36,7 +36,7 @@
   </exercise>
   <exercise xml:id="ez-trig-finding-angles-WW7" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q36">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q36.pg" />
-  </exercise> 
+  </exercise>
 
   <exercise xml:id="ez-trig-finding-angles-WW8" label="Library__Rochester__setTrig06Inverses__srw7_4_1">
     <webwork source="Library/Rochester/setTrig06Inverses/srw7_4_1.pg" />
@@ -49,7 +49,7 @@
   </exercise>
   <exercise xml:id="ez-trig-finding-angles-WW11" label="Library__Rochester__setTrig06Inverses__srw7_4_25">
     <webwork source="Library/Rochester/setTrig06Inverses/srw7_4_25.pg" />
-  </exercise>     
+  </exercise>
 -->
 
   <exercise xml:id="ez-finding-angles-plane">

--- a/source/exercises/ez-trig-finding-angles.xml
+++ b/source/exercises/ez-trig-finding-angles.xml
@@ -13,41 +13,41 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-trig-finding-angles">
   
-  <exercise xml:id="ez-trig-finding-angles-WW1">
+  <exercise xml:id="ez-trig-finding-angles-WW1" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q24a">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q24a.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-finding-angles-WW2">
+  <exercise xml:id="ez-trig-finding-angles-WW2" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q28">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q28.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-finding-angles-WW6">
+  <exercise xml:id="ez-trig-finding-angles-WW6" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q37">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q37.pg"/>
   </exercise>   
 
 <!--  most of the following fail to have statement tags
 
-  <exercise xml:id="ez-trig-finding-angles-WW3">
+  <exercise xml:id="ez-trig-finding-angles-WW3" label="Library__Rochester__setTrig06Inverses__srw7_6_25">
     <webwork source="Library/Rochester/setTrig06Inverses/srw7_6_25.pg" />
   </exercise>
-  <exercise xml:id="ez-trig-finding-angles-WW4">
+  <exercise xml:id="ez-trig-finding-angles-WW4" label="Library__Utah__Trigonometry__set7_Trigonometry__q3">
     <webwork source="Library/Utah/Trigonometry/set7_Trigonometry/q3.pg" />
   </exercise>
-  <exercise xml:id="ez-trig-finding-angles-WW5">
+  <exercise xml:id="ez-trig-finding-angles-WW5" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q203">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q203.pg" />
   </exercise>
-  <exercise xml:id="ez-trig-finding-angles-WW7">
+  <exercise xml:id="ez-trig-finding-angles-WW7" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q36">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q36.pg" />
   </exercise> 
 
-  <exercise xml:id="ez-trig-finding-angles-WW8">
+  <exercise xml:id="ez-trig-finding-angles-WW8" label="Library__Rochester__setTrig06Inverses__srw7_4_1">
     <webwork source="Library/Rochester/setTrig06Inverses/srw7_4_1.pg" />
   </exercise>
-  <exercise xml:id="ez-trig-finding-angles-WW9">
+  <exercise xml:id="ez-trig-finding-angles-WW9" label="Library__Rochester__setTrig06Inverses__srw7_4_3">
     <webwork source="Library/Rochester/setTrig06Inverses/srw7_4_3.pg" />
   </exercise>
-  <exercise xml:id="ez-trig-finding-angles-WW10">
+  <exercise xml:id="ez-trig-finding-angles-WW10" label="Library__Rochester__setTrig06Inverses__srw7_4_7">
     <webwork source="Library/Rochester/setTrig06Inverses/srw7_4_7.pg" />
   </exercise>
-  <exercise xml:id="ez-trig-finding-angles-WW11">
+  <exercise xml:id="ez-trig-finding-angles-WW11" label="Library__Rochester__setTrig06Inverses__srw7_4_25">
     <webwork source="Library/Rochester/setTrig06Inverses/srw7_4_25.pg" />
   </exercise>     
 -->

--- a/source/exercises/ez-trig-inverse.xml
+++ b/source/exercises/ez-trig-inverse.xml
@@ -13,16 +13,16 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-trig-inverse">
   
-  <exercise xml:id="ez-trig-inverse-WW1">
+  <exercise xml:id="ez-trig-inverse-WW1" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q07">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q07.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-inverse-WW2">
+  <exercise xml:id="ez-trig-inverse-WW2" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q08">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q08.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-inverse-WW3">
+  <exercise xml:id="ez-trig-inverse-WW3" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q09">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q09.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-inverse-WW4">
+  <exercise xml:id="ez-trig-inverse-WW4" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q14">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q14.pg"/>
   </exercise>
 

--- a/source/exercises/ez-trig-inverse.xml
+++ b/source/exercises/ez-trig-inverse.xml
@@ -12,7 +12,7 @@
 <!-- their respective owners.                                              -->
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-trig-inverse">
-  
+
   <exercise xml:id="ez-trig-inverse-WW1" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q07">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q07.pg"/>
   </exercise>
@@ -22,7 +22,7 @@
   <exercise xml:id="ez-trig-inverse-WW3" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q09">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q09.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-inverse-WW4" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q14">
+  <exercise xml:id="ez-trig-inverse-WW4" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q14-2">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q14.pg"/>
   </exercise>
 
@@ -121,7 +121,7 @@
             <p>
               For any real number <m>t</m>, <m>\arccos(\cos(t)) = t</m>.
             </p>
-          </li> 
+          </li>
           <li>
             <p>
               For any <m>y</m> such that <m>-1 \le y \le 1</m>, <m>\cos(\arccos(y)) = y</m>.
@@ -136,7 +136,7 @@
             <p>
               For any real number <m>t</m>, <m>\arctan(\tan(t)) = t</m>.
             </p>
-          </li>         
+          </li>
         </ol>
       </p>
     </statement>
@@ -155,7 +155,7 @@
   <exercise xml:id="ez-trig-inverse-3">
     <statement>
       <p>
-        Let's consider the composite function <m>h(x) = \cos(\arcsin(x))</m>.  This function makes sense to consider since the arcsine function produces an angle, at which the cosine function can then be evaluated.  In the questions that follow, we investigate how to express <m>h</m> without using trigonometric functions at all.  
+        Let's consider the composite function <m>h(x) = \cos(\arcsin(x))</m>.  This function makes sense to consider since the arcsine function produces an angle, at which the cosine function can then be evaluated.  In the questions that follow, we investigate how to express <m>h</m> without using trigonometric functions at all.
       </p>
 
       <p>

--- a/source/exercises/ez-trig-other.xml
+++ b/source/exercises/ez-trig-other.xml
@@ -14,13 +14,13 @@
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-trig-other">
   
 
-  <exercise xml:id="ez-trig-other-WW1">
+  <exercise xml:id="ez-trig-other-WW1" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q08-old">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q08-old.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-other-WW2">
+  <exercise xml:id="ez-trig-other-WW2" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q18">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q18.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-other-WW3">
+  <exercise xml:id="ez-trig-other-WW3" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Qtangent4">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Qtangent4.pg"/>
   </exercise>
 

--- a/source/exercises/ez-trig-right.xml
+++ b/source/exercises/ez-trig-right.xml
@@ -13,21 +13,21 @@
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-trig-right">
   
-  <exercise xml:id="ez-trig-right-WW1">
+  <exercise xml:id="ez-trig-right-WW1" label="Library__Rochester__setTrig03FunctionsRightAngle__p8">
     <webwork source="Library/Rochester/setTrig03FunctionsRightAngle/p8.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-right-WW4">
+  <exercise xml:id="ez-trig-right-WW4" label="Library__LoyolaChicago__Precalc__Chap6Tools__Connally3-6-Tools-20">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Tools/Connally3-6-Tools-20.pg"/>
   </exercise>
 
 <!--
-  <exercise xml:id="ez-trig-right-WW5">
+  <exercise xml:id="ez-trig-right-WW5" label="Library__Rochester__setTrig03FunctionsRightAngle__p6">
     <webwork source="Library/Rochester/setTrig03FunctionsRightAngle/p6.pg" />
   </exercise>
-  <exercise xml:id="ez-trig-right-WW2">
+  <exercise xml:id="ez-trig-right-WW2" label="Library__Rochester__setTrig03FunctionsRightAngle__p1">
     <webwork source="Library/Rochester/setTrig03FunctionsRightAngle/p1.pg" />
   </exercise>
-  <exercise xml:id="ez-trig-right-WW3">
+  <exercise xml:id="ez-trig-right-WW3" label="Library__LoyolaChicago__Precalc__Chap6Tools__Connally3-6-Tools-04__Connally3-6-Tools-04">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Tools/Connally3-6-Tools-04/Connally3-6-Tools-04.pg" />
   </exercise>
 -->

--- a/source/exercises/ez-trig-right.xml
+++ b/source/exercises/ez-trig-right.xml
@@ -12,8 +12,8 @@
 <!-- their respective owners.                                              -->
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-trig-right">
-  
-  <exercise xml:id="ez-trig-right-WW1" label="Library__Rochester__setTrig03FunctionsRightAngle__p8">
+
+  <exercise xml:id="ez-trig-right-WW1" label="Library__Rochester__setTrig03FunctionsRightAngle__p8-1">
     <webwork source="Library/Rochester/setTrig03FunctionsRightAngle/p8.pg"/>
   </exercise>
   <exercise xml:id="ez-trig-right-WW4" label="Library__LoyolaChicago__Precalc__Chap6Tools__Connally3-6-Tools-20">
@@ -53,7 +53,7 @@
   <exercise xml:id="ez-trig-right-rocket">
     <statement>
       <p>
-        A person watching a rocket launch uses a laser range-finder to measure the distance from themselves to the rocket.  The range-finder also reports the angle at which the finder is being elevated from horizontal.  At a certain instant, the range-finder reports that it is elevated at an angle of <m>17.4^\circ</m> from horizontal and that the distance to the rocket is <m>1650</m> meters.  How high off the ground is the rocket?  Assuming a straight-line vertical path for the rocket that is perpendicular to the earth, how far away was the rocket from the range-finder at the moment it was launched? 
+        A person watching a rocket launch uses a laser range-finder to measure the distance from themselves to the rocket.  The range-finder also reports the angle at which the finder is being elevated from horizontal.  At a certain instant, the range-finder reports that it is elevated at an angle of <m>17.4^\circ</m> from horizontal and that the distance to the rocket is <m>1650</m> meters.  How high off the ground is the rocket?  Assuming a straight-line vertical path for the rocket that is perpendicular to the earth, how far away was the rocket from the range-finder at the moment it was launched?
       </p>
     </statement>
     <answer>

--- a/source/exercises/ez-trig-tangent.xml
+++ b/source/exercises/ez-trig-tangent.xml
@@ -14,34 +14,34 @@
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-trig-tangent">
   
 
-  <exercise xml:id="ez-trig-tangent-WW1">
+  <exercise xml:id="ez-trig-tangent-WW1" label="Library__Rochester__setTrig02FunctionsUnitCircle__srw5_2_47">
     <webwork source="Library/Rochester/setTrig02FunctionsUnitCircle/srw5_2_47.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-tangent-WW2">
+  <exercise xml:id="ez-trig-tangent-WW2" label="Library__Rochester__setTrig03FunctionsRightAngle__p8">
     <webwork source="Library/Rochester/setTrig03FunctionsRightAngle/p8.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-tangent-WW3">
+  <exercise xml:id="ez-trig-tangent-WW3" label="Library__Rochester__setTrig03FunctionsRightAngle__p9">
     <webwork source="Library/Rochester/setTrig03FunctionsRightAngle/p9.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-trig-tangent-WW7">
+  <exercise xml:id="ez-trig-tangent-WW7" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q24a">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q24a.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-tangent-WW8">
+  <exercise xml:id="ez-trig-tangent-WW8" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q28">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q28.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-tangent-WW9">
+  <exercise xml:id="ez-trig-tangent-WW9" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q14">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q14.pg"/>
   </exercise>    
 
 <!--  
-  <exercise xml:id="ez-trig-tangent-WW4">
+  <exercise xml:id="ez-trig-tangent-WW4" label="Library__Rochester__setTrig03FunctionsRightAngle__p2">
     <webwork source="Library/Rochester/setTrig03FunctionsRightAngle/p2.pg" />
   </exercise>
-  <exercise xml:id="ez-trig-tangent-WW5">
+  <exercise xml:id="ez-trig-tangent-WW5" label="Library__Rochester__setTrig03FunctionsRightAngle__p1">
     <webwork source="Library/Rochester/setTrig03FunctionsRightAngle/p1.pg" />
   </exercise>
-  <exercise xml:id="ez-trig-tangent-WW6">
+  <exercise xml:id="ez-trig-tangent-WW6" label="Library__LoyolaChicago__Precalc__Chap6Tools__Connally3-6-Tools-02__Connally3-6-Tools-02">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Tools/Connally3-6-Tools-02/Connally3-6-Tools-02.pg" />
   </exercise>  
 -->  

--- a/source/exercises/ez-trig-tangent.xml
+++ b/source/exercises/ez-trig-tangent.xml
@@ -12,29 +12,29 @@
 <!-- their respective owners.                                              -->
 <!-- **********************************************************************-->
 <exercises xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="ez-trig-tangent">
-  
+
 
   <exercise xml:id="ez-trig-tangent-WW1" label="Library__Rochester__setTrig02FunctionsUnitCircle__srw5_2_47">
     <webwork source="Library/Rochester/setTrig02FunctionsUnitCircle/srw5_2_47.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-tangent-WW2" label="Library__Rochester__setTrig03FunctionsRightAngle__p8">
+  <exercise xml:id="ez-trig-tangent-WW2" label="Library__Rochester__setTrig03FunctionsRightAngle__p8-2">
     <webwork source="Library/Rochester/setTrig03FunctionsRightAngle/p8.pg"/>
   </exercise>
   <exercise xml:id="ez-trig-tangent-WW3" label="Library__Rochester__setTrig03FunctionsRightAngle__p9">
     <webwork source="Library/Rochester/setTrig03FunctionsRightAngle/p9.pg"/>
   </exercise>
 
-  <exercise xml:id="ez-trig-tangent-WW7" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q24a">
+  <exercise xml:id="ez-trig-tangent-WW7" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q24a-1">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q24a.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-tangent-WW8" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q28">
+  <exercise xml:id="ez-trig-tangent-WW8" label="Library__LoyolaChicago__Precalc__Chap6Sec6__Q28-1">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec6/Q28.pg"/>
   </exercise>
-  <exercise xml:id="ez-trig-tangent-WW9" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q14">
+  <exercise xml:id="ez-trig-tangent-WW9" label="Library__LoyolaChicago__Precalc__Chap6Sec7__Q14-1">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Sec7/Q14.pg"/>
-  </exercise>    
+  </exercise>
 
-<!--  
+<!--
   <exercise xml:id="ez-trig-tangent-WW4" label="Library__Rochester__setTrig03FunctionsRightAngle__p2">
     <webwork source="Library/Rochester/setTrig03FunctionsRightAngle/p2.pg" />
   </exercise>
@@ -43,8 +43,8 @@
   </exercise>
   <exercise xml:id="ez-trig-tangent-WW6" label="Library__LoyolaChicago__Precalc__Chap6Tools__Connally3-6-Tools-02__Connally3-6-Tools-02">
     <webwork source="Library/LoyolaChicago/Precalc/Chap6Tools/Connally3-6-Tools-02/Connally3-6-Tools-02.pg" />
-  </exercise>  
--->  
+  </exercise>
+-->
 
   <exercise xml:id="ez-trig-tangent-ramp">
     <statement>

--- a/source/exercises/misc.xml
+++ b/source/exercises/misc.xml
@@ -1,11 +1,11 @@
-  <exercise xml:id="ez-changing-linear-WW2">
+  <exercise xml:id="ez-changing-linear-WW2" label="Library__LoyolaChicago__Precalc__Chap1Sec1__Q29">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec1/Q29.pg" />
   </exercise>
 
-  <exercise xml:id="ez-changing-linear-WW1">
+  <exercise xml:id="ez-changing-linear-WW1" label="Library__LoyolaChicago__Precalc__Chap1Sec1__Q01">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec1/Q01.pg" />
   </exercise>
 
-  <exercise xml:id="ez-changing-linear-WW3">
+  <exercise xml:id="ez-changing-linear-WW3" label="Library__LoyolaChicago__Precalc__Chap1Sec1__Q05">
     <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec1/Q05.pg" />
   </exercise>


### PR DESCRIPTION
I asked ChatGPT to give me a script to convert the webwork addresses into labels following the model of ACS, and it worked beautifully.  

Then when trying to build I discovered there's 10 or so problems which appear in more than 1 section.  I left that situation as is and just added -1 or -2 to the end of the label so that the problems can be assigned multiple times.  It now builds just fine using CLI 2.43.1 and creates separate webwork files.